### PR TITLE
fixes #1

### DIFF
--- a/pypykatz_server/resultprocess.py
+++ b/pypykatz_server/resultprocess.py
@@ -10,6 +10,13 @@ class ResultProcessing(Process):
 		self.resQ = resQ
 		self.output_dir = output_dir
 		
+		if not os.path.exists(self.output_dir):
+			try:
+				os.makedirs(self.output_dir)
+			except Exception as e:
+				traceback.print_exc()
+		
+		
 	def run(self):
 		while True:
 			data = self.resQ.get()


### PR DESCRIPTION
`resultprocess.py's ResultProcessing.__init__()` will now try to create the passed in `output_dir` if it doesn't already exist, default or otherwise.